### PR TITLE
Rework structure of config exporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,6 @@ kubectl port-forward <kong_pod> 8001:8001
 
 Another option is deploing docker container with gongfig and use it as sidecar application.
 The image name is `eromanovskyj/gongfig`. You can also deploy a corresponding pod inside your kubernetes cluster, use `deployment.yml` for it.
+
+## Note
+As routes and services are requested simultaneously during config export, you need to use kong 0.14 or later in order to avoid [this bug](https://github.com/Kong/kong/issues/3440)

--- a/pkg/actions/const.go
+++ b/pkg/actions/const.go
@@ -1,3 +1,20 @@
 package actions
 
-var Apis = [...]string{"services", "routes"}
+const Services = "services"
+const Routes = "routes"
+
+type Resource struct {
+	path string
+	fields []string
+}
+
+var Apis = [...]Resource{
+	{
+	Services,
+	[]string{"name", "id", "host", "protocol", "read_timeout", "port", "path", "retries", "write_timeout"},
+	},
+	{
+	Routes,
+	[]string{"id", "paths", "hosts", "methods", "protocols"},
+	},
+}

--- a/pkg/actions/const.go
+++ b/pkg/actions/const.go
@@ -1,20 +1,6 @@
 package actions
 
-const Services = "services"
-const Routes = "routes"
+const ServicesKey = "services"
+const RoutesKey = "routes"
 
-type Resource struct {
-	path string
-	fields []string
-}
-
-var Apis = [...]Resource{
-	{
-	Services,
-	[]string{"name", "id", "host", "protocol", "read_timeout", "port", "path", "retries", "write_timeout"},
-	},
-	{
-	Routes,
-	[]string{"id", "paths", "hosts", "methods", "protocols"},
-	},
-}
+var Apis = []string{ServicesKey, RoutesKey}

--- a/pkg/actions/export.go
+++ b/pkg/actions/export.go
@@ -52,10 +52,10 @@ func Export(adminUrl string, filePath string) {
 	uri, _ := url.Parse(adminUrl)
 
 	for _, resource := range Apis {
-		uri.Path = resource
+		uri.Path = resource.path
 		fullPath := uri.String()
 
-		go getResourceList(client, writeData, fullPath, resource)
+		go getResourceList(client, writeData, fullPath, resource.path)
 
 	}
 

--- a/pkg/actions/export.go
+++ b/pkg/actions/export.go
@@ -8,20 +8,33 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"fmt"
+
+	"github.com/mitchellh/mapstructure"
 )
 
-type Data interface {}
+type Service struct {
+	Id string `json:"id"`
+	Name string `json:"name"`
+	Routes []Route
+}
+
+type Route struct {
+	Paths []string `json:"paths"`
+	Service Service `json:"service"`
+}
+
+type Data []interface{}
 
 // All items are contained of data property of json answer
 type resourceConfig struct {
-	Data *Data `json:"data"`
+	Data Data `json:"data"`
 }
 
 // resourceAnswer contains resource name and its configuration so
 // file writer can compose json with name as a key and complete resource configuration as a value
 type resourceAnswer struct {
 	resourceName string
-	config *Data
+	config Data
 }
 
 // Get list of resources by http and pass it to the channel where it will be writed to a disk
@@ -43,6 +56,40 @@ func getResourceList(client *http.Client, writeData chan *resourceAnswer, fullPa
 	writeData <- &resourceAnswer{resource, body.Data}
 }
 
+
+// Prepare config for writing: put routes as nested resources of services, omit unnecessary field etc
+func composeConfig(config map[string]Data) map[string]interface{} {
+	preparedConfig := make(map[string]interface{})
+	serviceMap := make(map[string]*Service)
+
+	// Create a map of services where key is service id in order to effectively
+	// search services for pasting there corresponding routes
+	for _, item := range config[ServicesKey] {
+		var service Service
+		mapstructure.Decode(item, &service)
+		serviceMap[service.Id] = &service
+	}
+
+	// Add routes to services as nested files so futher it will be written to a file
+	for _, item := range config[RoutesKey] {
+		var route Route
+		mapstructure.Decode(item, &route)
+		serviceMap[route.Service.Id].Routes = append(serviceMap[route.Service.Id].Routes, route)
+	}
+
+	services := []Service{}
+
+	// Rework serviceMap to a slice for writing it to the config file
+	// as service entity already has an id field and it does not need to duplicate it
+	for _, value := range serviceMap{
+		services = append(services, *value)
+	}
+
+	preparedConfig[ServicesKey] = services
+
+	return preparedConfig
+}
+
 func Export(adminUrl string, filePath string) {
 	client := &http.Client{Timeout: 10 * time.Second}
 
@@ -51,32 +98,37 @@ func Export(adminUrl string, filePath string) {
 	writeData := make(chan *resourceAnswer)
 	uri, _ := url.Parse(adminUrl)
 
+	// Collect representation of all resources
 	for _, resource := range Apis {
-		uri.Path = resource.path
+		uri.Path = resource
 		fullPath := uri.String()
 
-		go getResourceList(client, writeData, fullPath, resource.path)
+		go getResourceList(client, writeData, fullPath, resource)
 
 	}
 
 	resourcesNum := len(Apis)
 	config := map[string]Data{}
+	var preparedConfig map[string]interface{}
 
 	// Before writing to a file the program composes json
 	// It waits to obtain from channel exactly the same amount as number of resources
-	// After that it writes the data to a file and closes
+	// After that it composes the data in proper format, writes to a file and closes
 	for {
 		resource := <- writeData
 		config[resource.resourceName] = resource.config
 
 		resourcesNum--
 
+		// resourcesNum is 0 means all needed resources are collected
+		// and we can prepare config for writing it to a file
 		if resourcesNum == 0 {
+			preparedConfig = composeConfig(config)
 			break
 		}
 	}
 
-	jsonAnswer, _ := json.MarshalIndent(config, "", "    ")
+	jsonAnswer, _ := json.MarshalIndent(preparedConfig, "", "    ")
 	ioutil.WriteFile(filePath, jsonAnswer, 0644)
 	fmt.Println("Done")
 }


### PR DESCRIPTION
See the sample how exported config looks like
```
{
    "services": [
        {
            "name": "customer",
            "Routes": [
                {
                    "paths": [
                        "/rest/customer"
                    ]
                }
            ]
        },
        {
            "name": "orders",
            "Routes": [
                {
                    "paths": [
                        "/rest/orders"
                    ]
                }
            ]
        }
}
```