### PR TITLE
Support key-auth for consumer

### DIFF
--- a/pkg/actions/const.go
+++ b/pkg/actions/const.go
@@ -23,6 +23,10 @@ const ConsumersPath = "consumers"
 // KeyAuthsPath has Kong admin key authentication path
 const KeyAuthsPath = "key-auths"
 
+// KeyAuthPath has Kong admin key authentication path nested inside consumer
+const KeyAuthPath = "key-auth"
+
+
 // PluginsPath has Kong admin plugins path
 const PluginsPath = "plugins"
 

--- a/pkg/actions/const.go
+++ b/pkg/actions/const.go
@@ -20,6 +20,9 @@ const CertificatesPath = "certificates"
 // ConsumersPath has Kong admin consumers path
 const ConsumersPath = "consumers"
 
+// KeyAuthsPath has Kong admin key authentication path
+const KeyAuthsPath = "key-auths"
+
 // PluginsPath has Kong admin plugins path
 const PluginsPath = "plugins"
 
@@ -38,14 +41,13 @@ type Resource struct {
 // Apis - list of apis for import/export with corresponding structure types for parsing values
 // Be aware it should be in the same order as it is going to be deleted, e.g. firstly we delete
 // routes and then services as route has service foreign key
-var Apis = []string{RoutesPath, ServicesPath, CertificatesPath, ConsumersPath, PluginsPath, UpstreamsPath}
+var Apis = []string{RoutesPath, ServicesPath, CertificatesPath, ConsumersPath, KeyAuthsPath, PluginsPath, UpstreamsPath}
 
 // ExportResourceBundles is a slice of elements with resource path and corresponding struct type
 // in order to store elements in config while exporting using a loop, without duplicating a code.
 // Services and routes are not here as they handled separately in export procedure.
 var ExportResourceBundles  = []Resource{
 	{CertificatesPath, &Certificate{}},
-	{ConsumersPath, &Consumer{}},
 	{PluginsPath, &Plugin{}},
 }
 
@@ -95,6 +97,12 @@ type Consumer struct {
 	Id string         `json:"id,omitempty" mapstructure:"id"`
 	CustomId string   `json:"custom_id,omitempty" mapstructure:"custom_id"`
 	Username string   `json:"username,omitempty" mapstructure:"username"`
+	Key string 		  `json:"key,omitempty" mapstructure:"key"`
+}
+
+type KeyAuth struct {
+	Key string 		  `json:"key,omitempty" mapstructure:"key"`
+	ConsumerId string `json:"consumer_id,omitempty" mapstructure:"consumer_id"`
 }
 
 // Plugin struct - is used for managing plugins

--- a/pkg/actions/const.go
+++ b/pkg/actions/const.go
@@ -104,6 +104,7 @@ type Consumer struct {
 	Key string 		  `json:"key,omitempty" mapstructure:"key"`
 }
 
+//KeyAuth - for obtaining consumer KeyAuth
 type KeyAuth struct {
 	Key string 		  `json:"key,omitempty" mapstructure:"key"`
 	ConsumerId string `json:"consumer_id,omitempty" mapstructure:"consumer_id"`

--- a/pkg/actions/const.go
+++ b/pkg/actions/const.go
@@ -42,10 +42,14 @@ type Resource struct {
 	Struct interface{}
 }
 
+// FlushApies does not contain KeyAuthPath as these entries are deleted automatically
+// when corresponding consumer is deleted
+var FlushApis = []string{RoutesPath, ServicesPath, CertificatesPath, PluginsPath, UpstreamsPath, ConsumersPath}
+
 // Apis - list of apis for import/export with corresponding structure types for parsing values
 // Be aware it should be in the same order as it is going to be deleted, e.g. firstly we delete
 // routes and then services as route has service foreign key
-var Apis = []string{RoutesPath, ServicesPath, CertificatesPath, ConsumersPath, KeyAuthsPath, PluginsPath, UpstreamsPath}
+var Apis = append(FlushApis, KeyAuthsPath)
 
 // ExportResourceBundles is a slice of elements with resource path and corresponding struct type
 // in order to store elements in config while exporting using a loop, without duplicating a code.
@@ -53,12 +57,6 @@ var Apis = []string{RoutesPath, ServicesPath, CertificatesPath, ConsumersPath, K
 var ExportResourceBundles  = []Resource{
 	{CertificatesPath, &Certificate{}},
 	{PluginsPath, &Plugin{}},
-}
-
-// ImportResourceBundles is the same as ExportResourceBundles but for the import
-var ImportResourceBundles = []Resource{
-	{CertificatesPath, &Certificate{}},
-	{ConsumersPath, &Consumer{}},
 }
 
 //Service struct - is used for managing services

--- a/pkg/actions/flush.go
+++ b/pkg/actions/flush.go
@@ -20,14 +20,14 @@ func flushAll(adminURL string) {
 	flushData := make(chan *resourceAnswer)
 
 	// Collect representation of all resources
-	for _, resource := range Apis {
+	for _, resource := range FlushApis {
 		fullPath := getFullPath(adminURL, []string{resource})
 
 		go getResourceListToChan(client, flushData, fullPath, resource)
 
 	}
 
-	resourcesNum := len(Apis)
+	resourcesNum := len(FlushApis)
 	config := map[string]Data{}
 
 	for {
@@ -47,7 +47,7 @@ func flushAll(adminURL string) {
 func flushResources(client *http.Client, url string, config map[string]Data) {
 	// Firstly we need delete routes and only then services,
 	// as routes are nested resources of services
-	for _, resourceType := range Apis {
+	for _, resourceType := range FlushApis {
 		// In order to not overload the kong, limit concurrent post requests to 10
 		reqLimitChan := make(chan bool, 10)
 

--- a/pkg/actions/import.go
+++ b/pkg/actions/import.go
@@ -11,11 +11,13 @@ import (
 	"sync"
 )
 
+// ConcurrentStringMap - special map for synchronizing localIds with externals
 type ConcurrentStringMap struct {
 	sync.Mutex
 	store map[string]string
 }
 
+// Add - Locking is implemented in order to avoid problems with accessing to ConcurrentStringMap
 func (concurrentStringMap *ConcurrentStringMap) Add(key, value string) {
 	concurrentStringMap.Lock()
 	defer concurrentStringMap.Unlock()

--- a/pkg/actions/utils.go
+++ b/pkg/actions/utils.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"bytes"
 	"strings"
-	"github.com/jinzhu/copier"
 )
 
 // Data - general interface for storing json body answers
@@ -80,11 +79,8 @@ func requestNewResource(client *http.Client, resource interface{}, url string) (
 	return createdResource.Id, nil
 }
 
-func addResource(connectionBundle *ConnectionBundle, resource interface{}, idMap *ConcurrentStringMap) {
+func addResource(connectionBundle *ConnectionBundle, resource interface{}, resourceId string, idMap *ConcurrentStringMap) {
 	defer func() { <-connectionBundle.ReqLimitChan}()
-
-	var localResource LocalResource
-	copier.Copy(&localResource, &resource)
 
 	externalId, err := requestNewResource(connectionBundle.Client, resource, connectionBundle.URL)
 
@@ -92,7 +88,7 @@ func addResource(connectionBundle *ConnectionBundle, resource interface{}, idMap
 		log.Fatalf("Failed to create resource, %v\n", err)
 	}
 
-	idMap.Add(localResource.Id, externalId)
+	idMap.Add(resourceId, externalId)
 }
 
 func isJSONString(str string) bool {

--- a/pkg/actions/utils_test.go
+++ b/pkg/actions/utils_test.go
@@ -22,3 +22,9 @@ func getRoutesURL() string {
 	routesPathElements := []string{ServicesPath, TestEmailService.Name, RoutesPath}
 	return strings.Join(routesPathElements, "/")
 }
+
+func getConsumerKeyAuthURL(consumerId string) string {
+	//Create path /consumers/<consumer name>/key-auth
+	routesPathElements := []string{ConsumersPath, consumerId, KeyAuthPath}
+	return strings.Join(routesPathElements, "/")
+}


### PR DESCRIPTION
Currently, consumers are exported without API-keys even they have it. This PR fixes this issue. See #42 for more details.