### PR TITLE
Fix issue with pagination

### DIFF
--- a/pkg/actions/const.go
+++ b/pkg/actions/const.go
@@ -42,7 +42,7 @@ type Resource struct {
 	Struct interface{}
 }
 
-// FlushApies does not contain KeyAuthPath as these entries are deleted automatically
+// FlushApis does not contain KeyAuthPath as these entries are deleted automatically
 // when corresponding consumer is deleted
 var FlushApis = []string{RoutesPath, ServicesPath, CertificatesPath, PluginsPath, UpstreamsPath, ConsumersPath}
 

--- a/pkg/actions/export.go
+++ b/pkg/actions/export.go
@@ -32,7 +32,7 @@ func composeConfig(config map[string]Data, client *http.Client, url string) map[
 		serviceMap[service.Id] = &service
 	}
 
-	// Add routes to services as nested files so futher it will be written to a file
+	// Add routes to services as nested files so further it will be written to a file
 	for _, item := range config[RoutesPath] {
 		var route Route
 		mapstructure.Decode(item, &route)
@@ -87,7 +87,7 @@ func composeConfig(config map[string]Data, client *http.Client, url string) map[
 
 		// Compose path to particular target
 		instancePathElements := []string{UpstreamsPath, upstream.Id, TargetsPath}
-		upstreamTargetsURL := getFullPath(url, instancePathElements)
+		upstreamTargetsURL := getFullPath(url, instancePathElements, map[string]string{"size": "500"})
 		targets := getResourceList(client, upstreamTargetsURL)
 
 		for _, item := range targets.Data {
@@ -162,7 +162,8 @@ func getPreparedConfig(adminURL string) map[string]interface{} {
 
 	// Collect representation of all resources
 	for _, resource := range Apis {
-		fullPath := getFullPath(adminURL, []string{resource})
+		//size means limit for number of elements that will be obtained within one request
+		fullPath := getFullPath(adminURL, []string{resource}, map[string]string{"size": "500"})
 
 		go getResourceListToChan(client, writeData, fullPath, resource)
 

--- a/pkg/actions/export_test.go
+++ b/pkg/actions/export_test.go
@@ -148,12 +148,14 @@ func TestGetConsumersPreparedConfig(t *testing.T) {
 		t.Fatalf("2 consumers should be exported")
 	}
 
-	if consumers.Index(0).Interface().(Consumer).Username != consumer1Username {
-		t.Fatalf("First consumer should have name john")
+	username := consumers.Index(0).Interface().(Consumer).Username
+	if  username != consumer1Username{
+		t.Fatalf("First consumer should have name %s, but it has %s", consumer1Username, username)
 	}
 
-	if consumers.Index(0).Interface().(Consumer).Key != consumer1Key {
-		t.Fatalf("First consumer should have name john")
+	key := consumers.Index(0).Interface().(Consumer).Key
+	if key != consumer1Key {
+		t.Fatalf("First consumer should have key %s, but it has %s", consumer1Key, key)
 	}
 }
 

--- a/pkg/actions/export_test.go
+++ b/pkg/actions/export_test.go
@@ -20,7 +20,7 @@ func getTestServer(resourcePath, body string) (*httptest.Server, error) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		switch path := request.URL.Path[1:]; path {
+		switch path := getResourcePath(request.URL.Path); path {
 		case resourcePath:
 			w.WriteHeader(http.StatusOK)
 
@@ -39,7 +39,7 @@ func TestGetServicesAndRoutesPreparedConfig(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		switch path := request.URL.Path[1:]; path {
+		switch path := getResourcePath(request.URL.Path); path {
 
 		case ServicesPath:
 			w.WriteHeader(http.StatusOK)
@@ -126,7 +126,7 @@ func TestGetConsumersPreparedConfig(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		switch path := request.URL.Path[1:]; path {
+		switch path := getResourcePath(request.URL.Path); path {
 
 		case ConsumersPath:
 			w.WriteHeader(http.StatusOK)

--- a/pkg/actions/flush.go
+++ b/pkg/actions/flush.go
@@ -21,7 +21,7 @@ func flushAll(adminURL string) {
 
 	// Collect representation of all resources
 	for _, resource := range FlushApis {
-		fullPath := getFullPath(adminURL, []string{resource})
+		fullPath := getFullPath(adminURL, []string{resource}, map[string]string{"size": "500"})
 
 		go getResourceListToChan(client, flushData, fullPath, resource)
 
@@ -64,7 +64,7 @@ func flushResources(client *http.Client, url string, config map[string]Data) {
 				// Compose path to routes
 				instancePathElements := []string{resourceType, instance.Id}
 				instancePath := strings.Join(instancePathElements, "/")
-				instanceURL := getFullPath(url, []string{instancePath})
+				instanceURL := getFullPath(url, []string{instancePath}, map[string]string{})
 
 				request, _ := http.NewRequest(http.MethodDelete, instanceURL, nil)
 

--- a/pkg/actions/flush_test.go
+++ b/pkg/actions/flush_test.go
@@ -17,7 +17,7 @@ func TestConfigFlushed(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		switch path := request.URL.Path[1:]; path {
+		switch path := getResourcePath(request.URL.Path); path {
 
 		case ServicesPath:
 			w.WriteHeader(http.StatusOK)

--- a/pkg/actions/import.go
+++ b/pkg/actions/import.go
@@ -59,7 +59,7 @@ func createEntries(client *http.Client, adminURL string, configMap map[string][]
 	}
 
 
-	url := getFullPath(adminURL, []string{CertificatesPath})
+	url := getFullPath(adminURL, []string{CertificatesPath}, map[string]string{})
 
 	for _, item := range configMap[CertificatesPath] {
 		reqLimitChan <- true
@@ -72,7 +72,7 @@ func createEntries(client *http.Client, adminURL string, configMap map[string][]
 			certificate, certificate.Id, &concurrentStringMap)
 	}
 
-	url = getFullPath(adminURL, []string{ConsumersPath})
+	url = getFullPath(adminURL, []string{ConsumersPath}, map[string]string{})
 
 	for _, item := range configMap[ConsumersPath] {
 		reqLimitChan <- true
@@ -95,7 +95,7 @@ func createEntries(client *http.Client, adminURL string, configMap map[string][]
 		<- reqLimitChan
 	}
 
-	pluginsURL := getFullPath(adminURL, []string{PluginsPath})
+	pluginsURL := getFullPath(adminURL, []string{PluginsPath}, map[string]string{})
 
 	//Create plugins
 	for _, item := range configMap[PluginsPath] {
@@ -149,7 +149,9 @@ func createConsumersWithKeyAuths(requestBundle *ConnectionBundle, consumer Consu
 	idMap.Add(id, consumerExternalId)
 
 	if key != "" {
-		url := getFullPath(requestBundle.URL, []string{ConsumersPath, consumerExternalId, KeyAuthPath})
+		paths := []string{ConsumersPath, consumerExternalId, KeyAuthPath}
+
+		url := getFullPath(requestBundle.URL, paths, map[string]string{})
 		keyAuth := KeyAuth{Key: key}
 
 		_, err := requestNewResource(requestBundle.Client, keyAuth, url)
@@ -164,7 +166,7 @@ func createServiceWithRoutes(requestBundle *ConnectionBundle, service Service, i
 	defer func() { <-requestBundle.ReqLimitChan}()
 
 	// Get path to the services collection
-	servicesURL := getFullPath(requestBundle.URL, []string{ServicesPath})
+	servicesURL := getFullPath(requestBundle.URL, []string{ServicesPath}, map[string]string{})
 
 	// Clear routes field as it is created in separate request
 	routes := service.Routes
@@ -186,7 +188,7 @@ func createServiceWithRoutes(requestBundle *ConnectionBundle, service Service, i
 
 	// Compose path to routes
 	routesPathElements := []string{ServicesPath, service.Name, RoutesPath}
-	routesURL := getFullPath(requestBundle.URL, routesPathElements)
+	routesURL := getFullPath(requestBundle.URL, routesPathElements, map[string]string{})
 
 	// Create routes one by one
 	for _, route := range routes {
@@ -215,14 +217,16 @@ func createUpstreamsWithTargets(requestBundle *ConnectionBundle, upstream Upstre
 	// Clear id
 	upstream.Id = ""
 
-	upstreamsURL := getFullPath(requestBundle.URL, []string{UpstreamsPath})
+	upstreamsURL := getFullPath(requestBundle.URL, []string{UpstreamsPath}, map[string]string{})
 	_, err := requestNewResource(requestBundle.Client, upstream, upstreamsURL)
 
 	if err != nil {
 		log.Fatalf("Could not create new resource, %v\n", err)
 	}
 
-	targetsURL := getFullPath(requestBundle.URL, []string{UpstreamsPath, upstream.Name, TargetsPath})
+	paths := []string{UpstreamsPath, upstream.Name, TargetsPath}
+
+	targetsURL := getFullPath(requestBundle.URL, paths, map[string]string{})
 
 	for _, target := range targets {
 		_, err := requestNewResource(requestBundle.Client, target, targetsURL)

--- a/pkg/actions/import_test.go
+++ b/pkg/actions/import_test.go
@@ -72,7 +72,7 @@ func TestServiceWithRoutesCreated(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 		// Use path without slash ([1:])
-		switch path := request.URL.Path[1:]; path {
+		switch path := getResourcePath(request.URL.Path); path {
 		case ServicesPath:
 			var body Service
 			json.NewDecoder(request.Body).Decode(&body)
@@ -116,7 +116,7 @@ func TestCertificatesCreated(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 
 		// Use path without slash ([1:])
-		switch path := request.URL.Path[1:]; path {
+		switch path := getResourcePath(request.URL.Path); path {
 		case CertificatesPath:
 			var body Certificate
 			json.NewDecoder(request.Body).Decode(&body)
@@ -152,7 +152,7 @@ func TestPluginCreated(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 
 		// Use path without slash ([1:])
-		switch path := request.URL.Path[1:]; path {
+		switch path := getResourcePath(request.URL.Path); path {
 		case PluginsPath:
 			var body Plugin
 			json.NewDecoder(request.Body).Decode(&body)
@@ -188,7 +188,7 @@ func TestPluginCreatedForCorrespondingService(t *testing.T) {
 		serviceExternalId := "service1"
 
 		// Use path without slash ([1:])
-		switch path := request.URL.Path[1:]; path {
+		switch path := getResourcePath(request.URL.Path); path {
 		case ServicesPath:
 			body := fmt.Sprintf(`{"id": "%s"}`, serviceExternalId)
 			io.WriteString(w, body)
@@ -226,7 +226,7 @@ func TestPluginCreatedForCorrespondingRoute(t *testing.T) {
 		routeExternalId := "route2"
 
 		// Use path without slash ([1:])
-		switch path := request.URL.Path[1:]; path {
+		switch path := getResourcePath(request.URL.Path); path {
 		case ServicesPath:
 			body := `{"id": "service2"}`
 			io.WriteString(w, body)
@@ -264,7 +264,7 @@ func TestServiceCreatedRoutesFailed(t *testing.T) {
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 			// Use path without slash ([1:])
-			switch path := request.URL.Path[1:]; path {
+			switch path := getResourcePath(request.URL.Path); path {
 			case ServicesPath:
 				var body Service
 				json.NewDecoder(request.Body).Decode(&body)
@@ -307,7 +307,7 @@ func TestConsumerWithKeyAuthCreated(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 
 		// Use path without slash ([1:])
-		switch path := request.URL.Path[1:]; path {
+		switch path := getResourcePath(request.URL.Path); path {
 		case ConsumersPath:
 			body := fmt.Sprintf(`{"id": "%s"}`, externalConsumerId)
 			io.WriteString(w, body)

--- a/pkg/actions/utils.go
+++ b/pkg/actions/utils.go
@@ -1,11 +1,11 @@
 package actions
 
 import (
-	"net/url"
-	"net/http"
-	"log"
-	"encoding/json"
 	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -17,11 +17,21 @@ type resourceConfig struct {
 	Data Data `json:"data"`
 }
 
-// Get url and path and return concatenation
+// Get url, path items, query params and return concatenation
 // e.g http://localhost:8001, services will return http://localhost:8001/services
-func getFullPath(adminURL string, pathElements []string) string {
+func getFullPath(adminURL string, pathElements []string, params map[string]string) string {
 	uri, _ := url.Parse(adminURL)
 	path := strings.Join(pathElements, "/")
+
+	if len(params) > 0 {
+		q := uri.Query()
+		for key, value := range params {
+			q.Set(key, value)
+		}
+
+		uri.RawQuery = q.Encode()
+	}
+
 	uri.Path = path
 	return uri.String()
 }

--- a/pkg/actions/utils_test.go
+++ b/pkg/actions/utils_test.go
@@ -28,3 +28,16 @@ func getConsumerKeyAuthURL(consumerId string) string {
 	routesPathElements := []string{ConsumersPath, consumerId, KeyAuthPath}
 	return strings.Join(routesPathElements, "/")
 }
+
+func getResourcePath(path string) string {
+	// The function that turns "/resource?size=10" into "resource"
+	resourcePath := path[1:]
+
+	questionMarkIndex := strings.IndexByte(resourcePath, '?')
+
+	if questionMarkIndex > -1 {
+		resourcePath = resourcePath[:questionMarkIndex]
+	}
+
+	return resourcePath
+}


### PR DESCRIPTION
When there are more than 100 entities, pagination is enabled so it is not possible to get all entities and match them with related objects.

This is a quick fix that enables 500 items by default. Later, it will be implemented to obtain all items through pagination